### PR TITLE
Potential fix for code scanning alert no. 65: Database query built from user-controlled sources

### DIFF
--- a/src/apis/posts/posts-service.ts
+++ b/src/apis/posts/posts-service.ts
@@ -106,6 +106,10 @@ export class PostsService {
   }
 
   static async updateLikeCount(id: string, type: 'INCREMENT' | 'DECREMENT') {
+    // Prevent NoSQL injection: ensure id is not an object (e.g., a query operator)
+    if (typeof id !== 'string' || id.trim() === '' || id.startsWith('{')) {
+      throw new CustomError('VALIDATION_ERROR', 'Invalid ID');
+    }
     const result = await PostModel.findByIdAndUpdate(id, {
       $inc: { likeCount: type === 'INCREMENT' ? 1 : -1 },
     });


### PR DESCRIPTION
Potential fix for [https://github.com/muhsintt777/insta-server/security/code-scanning/65](https://github.com/muhsintt777/insta-server/security/code-scanning/65)

To fix this issue, we should enforce that the value passed as `id` (argument to `updateLikeCount` in `PostsService`) is always a *literal* value (string or ObjectId), never a query object. This can be handled at the entry point to this service method, i.e. before calling `updateLikeCount` (in `LikeService.createLike`), or we can do an additional check inside `PostsService.updateLikeCount` itself.

The best approach, given the information available, is to:
- Enhance the input validation by ensuring that, after any normalization, the `id` argument is strictly a string and *not* an object.
- Add a runtime check in `updateLikeCount` that throws an error if the provided `id` is an object (i.e., `{}` and not a string/ObjectId).
- This will block potential query operator objects and mitigate NoSQL injection risks.

The change should be made directly in the `updateLikeCount` method of `PostsService` in the file `src/apis/posts/posts-service.ts` before the database lookup. This check does not affect valid usage but prevents the vulnerable path.

To implement the change:
- Add a type check at the start of the `updateLikeCount` method to ensure `id` is a string or a valid ObjectId and *not* an object.
- If it isn't, throw a `CustomError('VALIDATION_ERROR', 'Invalid ID')` or similar.
- No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
