### PR TITLE
Potential fix for code scanning alert no. 22: Uncontrolled data used in path expression

### DIFF
--- a/src/utils/cloud-storage.ts
+++ b/src/utils/cloud-storage.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import { PutObjectRequest } from 'aws-sdk/clients/s3';
 import { ENV } from 'configs/env';
 import { storageBucket } from 'configs/storage-bucket';
@@ -8,8 +9,14 @@ type Folders = 'profile-images' | 'posts';
 
 export class CloudStorage {
   static async uploadFile(filePath: string, uploadFolder: Folders) {
+    const SAFE_UPLOAD_DIR = '/tmp'; // adjust if Multer uses another directory
     try {
-      const fileContent = fs.readFileSync(filePath);
+      // Validate that filePath is contained in SAFE_UPLOAD_DIR
+      const resolvedFilePath = path.resolve(filePath);
+      if (!resolvedFilePath.startsWith(path.resolve(SAFE_UPLOAD_DIR) + path.sep)) {
+        throw new CustomError('BAD_REQUEST', 'Invalid file path');
+      }
+      const fileContent = fs.readFileSync(resolvedFilePath);
 
       // create filename
       const originalName =
@@ -29,13 +36,20 @@ export class CloudStorage {
         Body: fileContent,
       };
       const result = await storageBucket.upload(params).promise();
-      fs.unlinkSync(filePath);
+      fs.unlinkSync(resolvedFilePath);
       return {
         url: result.Location,
         fileName: result.Key,
       };
     } catch (error) {
-      fs.unlinkSync(filePath);
+      try {
+        const resolvedFilePath = path.resolve(filePath);
+        if (resolvedFilePath.startsWith(path.resolve(SAFE_UPLOAD_DIR) + path.sep)) {
+          fs.unlinkSync(resolvedFilePath);
+        }
+      } catch (_) {
+        // swallow error
+      }
       throw new CustomError('INTERNAL_SERVER_ERROR', 'Failed to upload file');
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/muhsintt777/insta-server/security/code-scanning/22](https://github.com/muhsintt777/insta-server/security/code-scanning/22)

To fix this issue, we should validate that any files acted upon in `CloudStorage.uploadFile` are only accessed if they reside in a safe directory where Multer should be writing temporary files. This is best accomplished by resolving the absolute path and checking that it starts with the temp uploads directory used by Multer. If an attacker tries to supply a path outside this directory, the validation will fail, and the file will not be read or deleted.

Steps:

- Add logic to resolve `filePath` and make sure it is under a known temp uploads directory.
- If this check fails, throw an error rather than accessing or deleting the file.
- The temp directory should be set to match Multer's disk storage config. For simplicity, we'll use `/tmp/` (Linux default) but this should ideally be specified via configuration if Multer uses a different directory.

We'll need an import for `path` in `src/utils/cloud-storage.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
